### PR TITLE
fix initialize buffer

### DIFF
--- a/src/NLightning.Bolts/BOLT8/Services/TransportService.cs
+++ b/src/NLightning.Bolts/BOLT8/Services/TransportService.cs
@@ -52,7 +52,7 @@ public sealed class TransportService : ITransportService
             await stream.WriteAsync(writeBuffer.AsMemory()[..len]);
 
             // Read exactly 50 bytes
-            byte[] readBuffer = [50];
+            var readBuffer = new byte[50];
             await stream.ReadExactlyAsync(readBuffer);
 
             // Read Act Two and Write Act Three
@@ -63,7 +63,7 @@ public sealed class TransportService : ITransportService
         else
         {
             // Read exactly 50 bytes
-            byte[] readBuffer = [50];
+            var readBuffer = new byte[50];
             await stream.ReadExactlyAsync(readBuffer);
 
             // Read Act One and Write Act Two

--- a/test/NLightning.Bolts.Tests/BOLT8/Services/TransportServiceTests.cs
+++ b/test/NLightning.Bolts.Tests/BOLT8/Services/TransportServiceTests.cs
@@ -19,12 +19,20 @@ public partial class TransportServiceTests
             if (steps == 2)
             {
                 steps--;
+                if (inMessage.Length != 50 && inMessage.Length != 0)
+                {
+                    throw new InvalidOperationException("Expected 50 bytes");
+                }
                 outMessage = new byte[50];
                 return 50;
             }
             else if (steps == 1)
             {
                 steps--;
+                if (inMessage.Length != 50 && inMessage.Length != 66 && inMessage.Length != 0)
+                {
+                    throw new InvalidOperationException("Expected 66 bytes");
+                }
                 outMessage = new byte[66];
 
                 handshakeServiceMock.Object.SetTransport(new FakeTransport());


### PR DESCRIPTION
Fixed byte array initializer in `TransportService` method `Initialize()`.

I've confused the new byte initializer for the collection initializer, which was initializing a `byte[1] = { 50 };`.

Add check to tests.