### PR TITLE
create proxy class for bolt11 package

### DIFF
--- a/src/NLightning.Bolt11/InvoiceProxy.cs
+++ b/src/NLightning.Bolt11/InvoiceProxy.cs
@@ -1,0 +1,17 @@
+using NBitcoin;
+
+namespace NLightning.Bolt11;
+
+using Common.Types;
+
+public class Invoice : Bolts.BOLT11.Invoice
+{
+    public Invoice(ulong amountMilliSats, string description, uint256 paymentHash, uint256 paymentSecret) : base(amountMilliSats, description, paymentHash, paymentSecret)
+    { }
+
+    public Invoice(ulong amountMilliSats, uint256 descriptionHash, uint256 paymentHash, uint256 paymentSecret) : base(amountMilliSats, descriptionHash, paymentHash, paymentSecret)
+    { }
+
+    internal Invoice(Network network, ulong? amountMilliSats, long? timestamp = null) : base(network, amountMilliSats, timestamp)
+    { }
+}

--- a/src/NLightning.Bolt11/NLightning.Bolt11.csproj
+++ b/src/NLightning.Bolt11/NLightning.Bolt11.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Version>0.0.1</Version>
+    <Version>0.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,15 +14,15 @@
     <Copyright>Copyright © Níckolas Goline 2024</Copyright>
     <RepositoryUrl>https://github.com/ipms-io/nlightning</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <AssemblyVersion>0.0.1</AssemblyVersion>
-    <FileVersion>0.0.1</FileVersion>
+    <AssemblyVersion>0.1.0</AssemblyVersion>
+    <FileVersion>2</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
-    <Icon>logo_small.png</Icon>
+    <Icon>logo.png</Icon>
     <PackageTags>lightning,invoice,bolt11,encoder,decoder</PackageTags>
     <PackageProjectUrl>https://nlightning.ipms.io/api/NLightning.Bolts.BOLT11.html</PackageProjectUrl>
-    <PackageIcon>logo_small.png</PackageIcon>
+    <PackageIcon>logo.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\images\logo_small.png">
+    <None Include="..\..\images\logo.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>

--- a/src/NLightning.Bolts/BOLT11/Invoice.cs
+++ b/src/NLightning.Bolts/BOLT11/Invoice.cs
@@ -51,12 +51,12 @@ public partial class Invoice
     /// <summary>
     /// The network the invoice is created for
     /// </summary>
-    public Network Network { get; private set; }
+    public Network Network { get; }
 
     /// <summary>
     /// The amount of millisatoshis the invoice is for
     /// </summary>
-    public ulong AmountMilliSats { get; private set; }
+    public ulong AmountMilliSats { get; }
 
     /// <summary>
     /// The timestamp of the invoice
@@ -64,17 +64,17 @@ public partial class Invoice
     /// <remarks>
     /// The timestamp is the time the invoice was created in seconds since the Unix epoch.
     /// </remarks>
-    public long Timestamp { get; private set; }
+    public long Timestamp { get; }
 
     /// <summary>
     /// The signature of the invoice
     /// </summary>
-    public string Signature { get; private set; }
+    public string Signature { get; }
 
     /// <summary>
     /// The human-readable part of the invoice
     /// </summary>
-    public string HumanReadablePart { get; private set; }
+    public string HumanReadablePart { get; }
 
     /// <summary>
     /// The amount of satoshis the invoice is for
@@ -94,8 +94,8 @@ public partial class Invoice
     {
         get
         {
-            return _taggedFields.TryGet(TaggedFieldTypes.PAYMENT_HASH, out PaymentHashTaggedField paymentHash)
-                ? paymentHash.Value
+            return _taggedFields.TryGet(TaggedFieldTypes.PAYMENT_HASH, out PaymentHashTaggedField? paymentHash)
+                ? paymentHash!.Value
                 : new uint256();
         }
         set
@@ -116,8 +116,8 @@ public partial class Invoice
     {
         get
         {
-            return _taggedFields.TryGet(TaggedFieldTypes.ROUTING_INFO, out RoutingInfoTaggedField routingInfo)
-                ? routingInfo.Value
+            return _taggedFields.TryGet(TaggedFieldTypes.ROUTING_INFO, out RoutingInfoTaggedField? routingInfo)
+                ? routingInfo!.Value
                 : null;
         }
         set
@@ -140,8 +140,8 @@ public partial class Invoice
     {
         get
         {
-            return _taggedFields.TryGet(TaggedFieldTypes.FEATURES, out FeaturesTaggedField features)
-                ? features.Value
+            return _taggedFields.TryGet(TaggedFieldTypes.FEATURES, out FeaturesTaggedField? features)
+                ? features!.Value
                 : null;
         }
         set
@@ -164,8 +164,8 @@ public partial class Invoice
     {
         get
         {
-            return _taggedFields.TryGet(TaggedFieldTypes.EXPIRY_TIME, out ExpiryTimeTaggedField expireIn)
-                ? DateTimeOffset.FromUnixTimeSeconds(Timestamp + expireIn.Value)
+            return _taggedFields.TryGet(TaggedFieldTypes.EXPIRY_TIME, out ExpiryTimeTaggedField? expireIn)
+                ? DateTimeOffset.FromUnixTimeSeconds(Timestamp + expireIn!.Value)
                 : DateTimeOffset.FromUnixTimeSeconds(Timestamp + InvoiceConstants.DEFAULT_EXPIRATION_SECONDS);
         }
         set
@@ -216,8 +216,8 @@ public partial class Invoice
     {
         get
         {
-            return _taggedFields.TryGet(TaggedFieldTypes.DESCRIPTION, out DescriptionTaggedField description)
-                ? description.Value
+            return _taggedFields.TryGet(TaggedFieldTypes.DESCRIPTION, out DescriptionTaggedField? description)
+                ? description!.Value
                 : null;
         }
         set
@@ -240,8 +240,8 @@ public partial class Invoice
     {
         get
         {
-            return _taggedFields.TryGet(TaggedFieldTypes.PAYMENT_SECRET, out PaymentSecretTaggedField paymentSecret)
-                ? paymentSecret.Value
+            return _taggedFields.TryGet(TaggedFieldTypes.PAYMENT_SECRET, out PaymentSecretTaggedField? paymentSecret)
+                ? paymentSecret!.Value
                 : null;
         }
         set
@@ -264,8 +264,8 @@ public partial class Invoice
     {
         get
         {
-            return _taggedFields.TryGet(TaggedFieldTypes.PAYEE_PUB_KEY, out PayeePubKeyTaggedField payeePubKey)
-                ? payeePubKey.Value
+            return _taggedFields.TryGet(TaggedFieldTypes.PAYEE_PUB_KEY, out PayeePubKeyTaggedField? payeePubKey)
+                ? payeePubKey!.Value
                 : null;
         }
         set
@@ -288,8 +288,8 @@ public partial class Invoice
     {
         get
         {
-            return _taggedFields.TryGet(TaggedFieldTypes.DESCRIPTION_HASH, out DescriptionHashTaggedField descriptionHash)
-                ? descriptionHash.Value
+            return _taggedFields.TryGet(TaggedFieldTypes.DESCRIPTION_HASH, out DescriptionHashTaggedField? descriptionHash)
+                ? descriptionHash!.Value
                 : null;
         }
         set
@@ -311,8 +311,8 @@ public partial class Invoice
     {
         get
         {
-            return _taggedFields.TryGet(TaggedFieldTypes.MIN_FINAL_CLTV_EXPIRY, out MinFinalCltvExpiryTaggedField minFinalCltvExpiry)
-                ? minFinalCltvExpiry.Value
+            return _taggedFields.TryGet(TaggedFieldTypes.MIN_FINAL_CLTV_EXPIRY, out MinFinalCltvExpiryTaggedField? minFinalCltvExpiry)
+                ? minFinalCltvExpiry!.Value
                 : null;
         }
         set
@@ -334,8 +334,8 @@ public partial class Invoice
     {
         get
         {
-            return _taggedFields.TryGet(TaggedFieldTypes.METADATA, out MetadataTaggedField metadata)
-                ? metadata.Value
+            return _taggedFields.TryGet(TaggedFieldTypes.METADATA, out MetadataTaggedField? metadata)
+                ? metadata!.Value
                 : null;
         }
         set

--- a/test/NLightning.Bolts.Tests/BOLT11/IntegrationTests/InvoiceIntegrationTests.cs
+++ b/test/NLightning.Bolts.Tests/BOLT11/IntegrationTests/InvoiceIntegrationTests.cs
@@ -189,7 +189,6 @@ public class InvoiceIntegrationTests
         public long? ExpectedTimestamp;
         public readonly Dictionary<TaggedFieldTypes, object> EXPECTED_TAGGED_FIELDS = [];
         public bool IgnoreEncode;
-        public string? ErrorMessage;
     }
 
     private static List<TestInvoice> ReadTestInvoices(string filePath)
@@ -384,15 +383,6 @@ public class InvoiceIntegrationTests
                 }
 
                 currentInvoice.IgnoreEncode = bool.Parse(line[13..]);
-            }
-            else if (line.StartsWith("error="))
-            {
-                if (currentInvoice == null)
-                {
-                    throw new InvalidOperationException("error line without invoice line");
-                }
-
-                currentInvoice.ErrorMessage = line[6..];
             }
             else if (line.Length == 0)
             {


### PR DESCRIPTION
add proxy class on bolt11 so devs have an Invoice API using `NLightning.Bolt11` instead of `NLightning.Bolts.BOLT11`.
This makes it straightforward to use the API for devs just interested in this package.