### PR TITLE
set CheckForOverflowUnderflow to false when package is wasm

### DIFF
--- a/src/NLightning.Bolt11/NLightning.Bolt11.csproj
+++ b/src/NLightning.Bolt11/NLightning.Bolt11.csproj
@@ -10,7 +10,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Version>0.2.0</Version>
+    <Version>0.2.2</Version>
     <Configurations>Debug;Debug.Native;Debug.Wasm;Release;Release.Native;Release.Wasm</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
@@ -21,8 +21,8 @@
     <Copyright>Copyright © Níckolas Goline 2024</Copyright>
     <RepositoryUrl>https://github.com/ipms-io/nlightning</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <AssemblyVersion>0.2.0</AssemblyVersion>
-    <FileVersion>0.2.0</FileVersion>
+    <AssemblyVersion>0.2.2</AssemblyVersion>
+    <FileVersion>0.2.2</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Icon>logo.png</Icon>
     <PackageTags>lightning,invoice,bolt11,encoder,decoder</PackageTags>
@@ -66,7 +66,7 @@
     <DefineConstants>CRYPTO_JS;$(DefineConstants)</DefineConstants>
     <PackageId>NLightning.Bolt11.Blazor</PackageId>
     <AssemblyName>NLightning.Bolt11.Blazor</AssemblyName>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' Or $(Configuration.Contains('.Wasm'))">

--- a/src/NLightning.Common/NLightning.Common.csproj
+++ b/src/NLightning.Common/NLightning.Common.csproj
@@ -52,6 +52,7 @@
     <DefineConstants>CRYPTO_JS;$(DefineConstants)</DefineConstants>
     <PackageId>NLightning.Common.Blazor</PackageId>
     <AssemblyName>NLightning.Common.Blazor</AssemblyName>
+    <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' Or $(Configuration.Contains('.Wasm'))">


### PR DESCRIPTION
This was building operations like the one in `NLightning.Common.BitUtils.BitReader` line 56 in IL with `checked()`, which throws an exception because of an overflow.