### PR TITLE
Add Validate required fields during invoice decoding

### DIFF
--- a/src/NLightning.Bolt11/Models/Invoice.cs
+++ b/src/NLightning.Bolt11/Models/Invoice.cs
@@ -537,6 +537,8 @@ public partial class Invoice
             var invoice = new Invoice(invoiceString, hrp, network, amount, timestamp, taggedFields,
                                       new CompactSignature(signature[^1], signature[..^1]));
 
+            invoice.ValidateRequiredFields();
+
             // Get pubkey from tagged fields
             if (taggedFields.TryGet(TaggedFieldTypes.PayeePubKey, out PayeePubKeyTaggedField? pubkeyTaggedField))
             {
@@ -553,6 +555,42 @@ public partial class Invoice
         }
     }
     #endregion
+
+    private void ValidateRequiredFields()
+    {
+        if (PaymentHash == uint256.Zero)
+        {
+            throw new ArgumentException("Invalid payment_hash.");
+        }
+
+        if (PaymentSecret == uint256.Zero)
+        {
+            throw new ArgumentException("Invalid payment_secret.");
+        }
+
+        bool hasDescription = !string.IsNullOrWhiteSpace(Description);
+        bool hasDescriptionHash = DescriptionHash != null && DescriptionHash != uint256.Zero;
+
+        if (!hasDescription && !hasDescriptionHash)
+        {
+            throw new ArgumentException("Missing description or description_hash.");
+        }
+
+        if (hasDescription && hasDescriptionHash)
+        {
+            throw new ArgumentException("Only one of description or description_hash is allowed.");
+        }
+
+        if (hasDescription && Encoding.UTF8.GetByteCount(Description) > 639)
+        {
+            throw new ArgumentException("Description length must not exceed 639 bytes.");
+        }
+
+        if (hasDescriptionHash && DescriptionHash == uint256.Zero)
+        {
+            throw new ArgumentException("Description hash is invalid or zero.");
+        }
+    }
 
     /// <summary>
     /// Encodes the current invoice into a lightning-compatible invoice format as a string.

--- a/test/NLightning.Integration.Tests/BOLT11/InvoiceIntegrationTests.cs
+++ b/test/NLightning.Integration.Tests/BOLT11/InvoiceIntegrationTests.cs
@@ -112,6 +112,9 @@ public class InvoiceIntegrationTests
                 "lnbc2500x1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgqrrzc4cvfue4zp3hggxp47ag7xnrlr8vgcmkjxk3j5jqethnumgkpqp23z9jclu3v0a7e0aruz366e9wqdykw6dxhdzcjjhldxq0w6wgqcnu43j")]
     [InlineData("Invalid pico amount in invoice",
                 "lnbc2500000001p1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9qrsgq0lzc236j96a95uv0m3umg28gclm5lqxtqqwk32uuk4k6673k6n5kfvx3d2h8s295fad45fdhmusm8sjudfhlf6dcsxmfvkeywmjdkxcp99202x")]
+    [InlineData("Invalid payment_secret.",
+                "lnbc16lta047pp5h6lta047h6lta047h6lta047h6lta047h6lta047h6lta047h6lqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqh6lqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqh6lqqqqqqqqqqqqqqqqqqqt703rz")]
+
     public void Given_InvalidInvoiceString_When_Decoding_Then_ExceptionIsThrown(
         string errorMessage, string? invoiceString)
     {


### PR DESCRIPTION
This PR adds validation logic to the invoice decoding process to ensure compliance with the BOLT11 specification regarding required fields.

#### What it does

- Introduces a `ValidateRequiredFields()` method.
- Calls this method during invoice decoding.
- Enforces the following rules:
  - `payment_hash` must not be zero.
  - `payment_secret` must not be zero.
  - Exactly one of `description` or `description_hash` must be present.
  - If `description` is used, its UTF-8 byte length must not exceed 639.
  - If `description_hash` is used, it must not be zero.