### PR TITLE
Allow for extensible `BitcoinNetwork`

### DIFF
--- a/src/NLightning.Domain/CHANGELOG.md
+++ b/src/NLightning.Domain/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.1.0
+
+This version introduces the ability to register and manage custom Bitcoin-like networks at runtime, enhancing the
+flexibility and extensibility of the `BitcoinNetwork` class. This allows developers to define and work with networks
+beyond the standard `mainnet`, `testnet`, and `regtest`, making the library more adaptable to various use cases and
+testing scenarios.
+
+### Added
+
+- **Extensible Custom Bitcoin Networks:**  
+  `BitcoinNetwork` now supports registration and management of custom network names and corresponding `ChainHash` values
+  at runtime.
+    - Implementers can register any custom Bitcoin-like network and have it fully supported throughout the domain layer.
+    - Provides methods to register and unregister custom networks and retrieve their `ChainHash` from name, with all
+      conversions and equality logic preserved.
+    - Built-in networks (`mainnet`, `testnet`, `regtest`) remain unchanged.
+
 ## v1.0.0
 
 This version's focus has been on enhancing Bitcoin integration, refining channel management, standardizing protocol

--- a/src/NLightning.Domain/NLightning.Domain.csproj
+++ b/src/NLightning.Domain/NLightning.Domain.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Configurations>Debug;Release;Debug.Native;Debug.Wasm;Release.Native;Release.Wasm</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
@@ -16,8 +16,8 @@
     <Copyright>Copyright © Níckolas Goline 2024-2025</Copyright>
     <RepositoryUrl>https://github.com/ipms-io/nlightning</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
-    <FileVersion>1.0.0</FileVersion>
+    <AssemblyVersion>1.1.0</AssemblyVersion>
+    <FileVersion>1.1.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Icon>logo.png</Icon>
     <PackageTags>lightning-network,bitcoin,crypto,infrastructure,dotnet,cryptography,cross-platform,libsodium,blazor,webassembly,aot</PackageTags>
@@ -26,7 +26,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageId>NLightning.Domain</PackageId>
-    <PackageReleaseNotes>This version's focus has been on enhancing Bitcoin integration, refining channel management, standardizing protocol message handling, and improving core domain primitives. These changes aim to solidify the domain logic and provide a richer, more robust foundation for building Lightning Network features.</PackageReleaseNotes>
+    <PackageReleaseNotes>This version introduces the ability to register and manage custom Bitcoin-like networks at runtime, enhancing the flexibility and extensibility of the `BitcoinNetwork` class. This allows developers to define and work with networks beyond the standard `mainnet`, `testnet`, and `regtest`, making the library more adaptable to various use cases and testing scenarios.</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('Debug'))">

--- a/src/NLightning.Domain/Protocol/ValueObjects/BitcoinNetwork.cs
+++ b/src/NLightning.Domain/Protocol/ValueObjects/BitcoinNetwork.cs
@@ -29,21 +29,27 @@ public readonly struct BitcoinNetwork : IEquatable<BitcoinNetwork>
                 NetworkConstants.Regtest => ChainConstants.Regtest,
                 _ => CustomChainHashes.TryGetValue(Name.ToLowerInvariant(), out var hash)
                          ? hash
-                         : throw new Exception($"Chain not supported: {Name}")
+                         : throw new InvalidOperationException($"Chain not supported: {Name}")
             };
         }
     }
 
+    public override string ToString() => Name;
+
     /// <summary>
     /// Register a custom network mapping
     /// </summary>
-    public override string ToString() => Name;
-
     public void Register(string name, ChainHash chainHash)
     {
         if (string.IsNullOrWhiteSpace(name)) throw new ArgumentNullException(nameof(name));
 
-        CustomChainHashes.TryAdd(name.ToLowerInvariant(), chainHash);
+        if (!CustomChainHashes.TryAdd(name.ToLowerInvariant(), chainHash))
+        {
+            if (CustomChainHashes.ContainsKey(name.ToLowerInvariant()))
+                throw new InvalidOperationException($"Chain hash already registered: {name}");
+
+            throw new InvalidOperationException($"Failed to register chain hash: {name}");
+        }
     }
 
     /// <summary>

--- a/src/NLightning.Domain/Protocol/ValueObjects/BitcoinNetwork.cs
+++ b/src/NLightning.Domain/Protocol/ValueObjects/BitcoinNetwork.cs
@@ -4,6 +4,8 @@ using Constants;
 
 public readonly struct BitcoinNetwork : IEquatable<BitcoinNetwork>
 {
+    private static Dictionary<string, ChainHash> CustomChainHashes { get; } = new();
+
     public static readonly BitcoinNetwork Mainnet = new(NetworkConstants.Mainnet);
     public static readonly BitcoinNetwork Testnet = new(NetworkConstants.Testnet);
     public static readonly BitcoinNetwork Regtest = new(NetworkConstants.Regtest);
@@ -25,19 +27,43 @@ public readonly struct BitcoinNetwork : IEquatable<BitcoinNetwork>
                 NetworkConstants.Mainnet => ChainConstants.Main,
                 NetworkConstants.Testnet => ChainConstants.Testnet,
                 NetworkConstants.Regtest => ChainConstants.Regtest,
-                _ => throw new Exception("Chain not supported.")
+                _ => CustomChainHashes.TryGetValue(Name.ToLowerInvariant(), out var hash)
+                         ? hash
+                         : throw new Exception($"Chain not supported: {Name}")
             };
         }
     }
 
+    /// <summary>
+    /// Register a custom network mapping
+    /// </summary>
     public override string ToString() => Name;
 
+    public void Register(string name, ChainHash chainHash)
+    {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentNullException(nameof(name));
+
+        CustomChainHashes.TryAdd(name.ToLowerInvariant(), chainHash);
+    }
+
+    /// <summary>
+    /// Unregister a custom network mapping
+    /// </summary>
+    public static void Unregister(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentNullException(nameof(name));
+        CustomChainHashes.Remove(name.ToLowerInvariant());
+    }
+
     #region Implicit Conversions
+
     public static implicit operator string(BitcoinNetwork bitcoinNetwork) => bitcoinNetwork.Name.ToLowerInvariant();
     public static implicit operator BitcoinNetwork(string value) => new(value.ToLowerInvariant());
+
     #endregion
 
     #region Equality
+
     public override bool Equals(object? obj)
     {
         return obj is BitcoinNetwork network && ChainHash.Equals(network.ChainHash);
@@ -62,5 +88,6 @@ public readonly struct BitcoinNetwork : IEquatable<BitcoinNetwork>
     {
         return !(left == right);
     }
+
     #endregion
 }


### PR DESCRIPTION
Add extensibility to `BitcoinNetwork` to allow it's usage in Signets.