### PR TITLE
remove span size check on `BitReader`

### DIFF
--- a/src/NLightning.Bolt11/CHANGELOG.md
+++ b/src/NLightning.Bolt11/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.0.3
+
+Fixed an error where decoding `PayeePubKeyTaggedField` resulted in error.
+
+### Removed
+
+- Removed Span size check from `BitReader.ReadBits`.
+
 ## v4.0.2
 
 Bump version to use latest `NLightning.Infrastructure`

--- a/src/NLightning.Bolt11/NLightning.Bolt11.csproj
+++ b/src/NLightning.Bolt11/NLightning.Bolt11.csproj
@@ -11,7 +11,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Version>4.0.2</Version>
+    <Version>4.0.3</Version>
     <Configurations>Debug;Debug.Native;Debug.Wasm;Release;Release.Native;Release.Wasm</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
@@ -22,8 +22,8 @@
     <Copyright>Copyright © Níckolas Goline 2024-2025</Copyright>
     <RepositoryUrl>https://github.com/ipms-io/nlightning</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <AssemblyVersion>4.0.2</AssemblyVersion>
-    <FileVersion>4.0.2</FileVersion>
+    <AssemblyVersion>4.0.3</AssemblyVersion>
+    <FileVersion>4.0.3</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Icon>logo.png</Icon>
     <PackageTags>lightning,invoice,bolt11,encoder,decoder</PackageTags>
@@ -32,7 +32,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageId>NLightning.Bolt11</PackageId>
-    <PackageReleaseNotes>Fixed `TaggedFieldList` logic to accept zero length description on an invoice.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed an error where decoding `PayeePubKeyTaggedField` resulted in error.</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.Contains('Debug'))">

--- a/src/NLightning.Domain/Utils/BitReader.cs
+++ b/src/NLightning.Domain/Utils/BitReader.cs
@@ -30,12 +30,6 @@ public class BitReader(byte[] buffer) : IBitReader
         if (bitLength == 0)
             return 0;
 
-        var bytesNeeded = (bitLength + 7) / 8;
-        if (valueOffset + bytesNeeded > value.Length)
-            throw new ArgumentException("Destination span is too small for the requested bit length.", nameof(value));
-
-        value[valueOffset..(valueOffset + bytesNeeded)].Clear();
-
         var byteOffset = _bitOffset / 8;
         var shift = (int)((uint)_bitOffset % 8);
 


### PR DESCRIPTION
Checking for size is very complex and each `TaggedField` knows how to deal with itself.