### PR TITLE
Fix custom_lnd Dockerfile mkdir existing directory in debian stable slim

### DIFF
--- a/test/Docker/custom_lnd/Dockerfile
+++ b/test/Docker/custom_lnd/Dockerfile
@@ -16,7 +16,7 @@ RUN SYS_ARCH="$(dpkg --print-architecture)" \
   && rm *.tar.gz
 
 RUN curl -SLO https://raw.githubusercontent.com/lightningnetwork/lnd/master/contrib/lncli.bash-completion \
-  && mkdir /etc/bash_completion.d \
+  && mkdir -p /etc/bash_completion.d \
   && mv lncli.bash-completion /etc/bash_completion.d/ \
   && curl -SLO https://raw.githubusercontent.com/scop/bash-completion/master/bash_completion \
   && mv bash_completion /usr/share/bash-completion/


### PR DESCRIPTION
This PR fixes the build failure of custom_lnd Dockerfile on current debian:stable-slim.
Fixes #76